### PR TITLE
Fix MA memory index width - this was one of the 35 linter warnings

### DIFF
--- a/src/MA.sv
+++ b/src/MA.sv
@@ -8,6 +8,11 @@ module MA #( parameter SIZE = 1024 )
 
   reg [31:0] M[0:SIZE -1];
 
+  localparam int WORDS = SIZE;
+  localparam int IDX_W = (WORDS <= 1) ? 1 : $clog2(WORDS);
+  wire [IDX_W-1:0] word_idx = address[IDX_W+1:2]; // word address bits (byte addr -> word idx)
+
+
 `ifndef UTOSS_RISCV_HARDENING
   initial begin
     string mem_file;
@@ -21,12 +26,12 @@ module MA #( parameter SIZE = 1024 )
 `endif
 
   always @(posedge clk) begin
-    read_data <= M[address[31:2]]; // 2 LSBs used for byte addressing
+    read_data <= M[word_idx]; // 2 LSBs used for byte addressing
 
-    if (write_enable[0]) M[address[31:2]][7:0]   <= write_data[7:0];
-    if (write_enable[1]) M[address[31:2]][15:8]  <= write_data[15:8];
-    if (write_enable[2]) M[address[31:2]][23:16] <= write_data[23:16];
-    if (write_enable[3]) M[address[31:2]][31:24] <= write_data[31:24];
+    if (write_enable[0]) M[word_idx][7:0]   <= write_data[7:0];
+    if (write_enable[1]) M[word_idx][15:8]  <= write_data[15:8];
+    if (write_enable[2]) M[word_idx][23:16] <= write_data[23:16];
+    if (write_enable[3]) M[word_idx][31:24] <= write_data[31:24];
   end
 
 endmodule


### PR DESCRIPTION
pushing to origin